### PR TITLE
Load Cloudcontrol token via Environment first

### DIFF
--- a/cctrl/auth.py
+++ b/cctrl/auth.py
@@ -59,6 +59,7 @@ def read_tokenfile():
         except ValueError:
             token = None
         token_file.close()
+    token = os.environ.get('CLOUDCONTROL_TOKEN', token)
     return token
 
 


### PR DESCRIPTION
Loading a token from the environment helps integrating CloudControl
with continuous integration services (e.g. Railsonfire) as then only
an environment value needs to be set
