### PR TITLE
Feature/config file

### DIFF
--- a/cctrl/auth.py
+++ b/cctrl/auth.py
@@ -102,10 +102,16 @@ def read_configfile():
             # fall through to normal authorization
             pass
 
-def write_configfile(overwrite=False):
-    email, password = get_credentials(read=False)
-    with open(CONFIG_FILE_PATH, 'w') as config_fp:
-        config_fp.write(json.dumps({'email': email, 'password': password}))
+
+def write_configfile(*args):
+    if os.path.exists(CONFIG_FILE_PATH):
+        question = raw_input(
+                "'%s' exsits, type 'Yes' without the quotes to overwrite:"
+                % CONFIG_FILE_PATH)
+    if question.lower() == 'yes':
+        email, password = get_credentials(read=False)
+        with open(CONFIG_FILE_PATH, 'w') as config_fp:
+            config_fp.write(json.dumps({'email': email, 'password': password}))
 
 
 def get_credentials(create=False, read=True):

--- a/cctrl/auth.py
+++ b/cctrl/auth.py
@@ -92,14 +92,7 @@ def delete_tokenfile():
     return False
 
 
-def get_credentials(create=False):
-    """
-        We use this to ask the user for his credentials in case we have no
-        valid token.
-        If create is true, the user is asked twice for the password,
-        to make sure, that no typing error occurred. This is done three times
-        after that a PasswordsDontMatchException is thrown.
-    """
+def read_configfile():
     if os.path.exists(CONFIG_FILE_PATH):
         try:
             with open(CONFIG_FILE_PATH) as config_fp:
@@ -108,6 +101,25 @@ def get_credentials(create=False):
         except (ValueError, IOError, KeyError):
             # fall through to normal authorization
             pass
+
+def write_configfile(overwrite=False):
+    email, password = get_credentials(read=False)
+    with open(CONFIG_FILE_PATH, 'w') as config_fp:
+        config_fp.write(json.dumps({'email': email, 'password': password}))
+
+
+def get_credentials(create=False, read=True):
+    """
+        We use this to ask the user for his credentials in case we have no
+        valid token.
+        If create is true, the user is asked twice for the password,
+        to make sure, that no typing error occurred. This is done three times
+        after that a PasswordsDontMatchException is thrown.
+    """
+    if read:
+        credentials = read_configfile()
+        if credentials is not None:
+            return credentials
     email = raw_input('Email   : ')
     password = None
     for i in range(3):

--- a/cctrl/auth.py
+++ b/cctrl/auth.py
@@ -27,7 +27,7 @@ except ImportError:
     import simplejson as json
 
 from cctrl.error import messages, PasswordsDontMatchException
-from cctrl.settings import TOKEN_FILE_PATH, HOME_PATH
+from cctrl.settings import TOKEN_FILE_PATH, HOME_PATH, CONFIG_FILE_PATH
 
 
 def update_tokenfile(api):
@@ -100,6 +100,14 @@ def get_credentials(create=False):
         to make sure, that no typing error occurred. This is done three times
         after that a PasswordsDontMatchException is thrown.
     """
+    if os.path.exists(CONFIG_FILE_PATH):
+        try:
+            with open(CONFIG_FILE_PATH) as config_fp:
+                config_json = json.loads(config_fp.read())
+            return config_json['email'], config_json['password']
+        except (ValueError, IOError, KeyError):
+            # fall through to normal authorization
+            pass
     email = raw_input('Email   : ')
     password = None
     for i in range(3):

--- a/cctrl/cctrluser
+++ b/cctrl/cctrluser
@@ -27,6 +27,7 @@ import cctrl.settings as settings
 import cctrl.common as common
 from cctrl.user import UserController
 from cctrl.output import get_version
+from cctrl.auth import write_configfile
 
 
 def main(api):
@@ -135,6 +136,11 @@ def parse_cmdline(user):
         'logout',
         help="logout - this deletes the saved token")
     logout_subparser.set_defaults(func=user.logout)
+
+    logout_subparser = subparsers.add_parser(
+        'store',
+        help="store the credentials locally")
+    logout_subparser.set_defaults(func=write_configfile)
 
     args = parser.parse_args()
 

--- a/cctrl/settings.py
+++ b/cctrl/settings.py
@@ -21,7 +21,7 @@ from cctrl.version import __version__
 HOME_PATH = os.path.abspath(os.path.expanduser('~/.cloudControl'))
 TOKEN_FILE_NAME = 'token.json'
 TOKEN_FILE_PATH = os.path.join(HOME_PATH, TOKEN_FILE_NAME)
-CONFIG_FILE_NAME = 'config.json'
+CONFIG_FILE_NAME = os.environ.get('CONFIG_FILE_NAME', 'config.json')
 CONFIG_FILE_PATH = os.path.join(HOME_PATH, CONFIG_FILE_NAME)
 CACHE_DIR = None
 VERSION = __version__

--- a/cctrl/settings.py
+++ b/cctrl/settings.py
@@ -21,5 +21,7 @@ from cctrl.version import __version__
 HOME_PATH = os.path.abspath(os.path.expanduser('~/.cloudControl'))
 TOKEN_FILE_NAME = 'token.json'
 TOKEN_FILE_PATH = os.path.join(HOME_PATH, TOKEN_FILE_NAME)
+CONFIG_FILE_NAME = 'config.json'
+CONFIG_FILE_PATH = os.path.join(HOME_PATH, CONFIG_FILE_NAME)
 CACHE_DIR = None
 VERSION = __version__


### PR DESCRIPTION
This implements caching the credentials locally in a config file. The file
format is JSON and can be configured with an environment variable. Also, a new
subcommand 'store' is implemented to allows storing the credentials. Of course,
if this makes it in, documentation should be added and an additional warning
should be included that the user is storing his/her credentials in PLAINTEXT on
the local filesystem.

I wrote this because I became really annoyed with having to type my username
and password over and over and over again. The timeout of the token is simply
too short. In an ideal world, cctrl would authenticate against stored ssh keys,
the way you do it with git when you push the deployment with bare git -- but
that needs to be done on the remote side.
