### PR TITLE
Use pipes.quote to escape output so it is reusable on shell

### DIFF
--- a/cctrl/output.py
+++ b/cctrl/output.py
@@ -504,4 +504,4 @@ def print_config(config, key=None):
         print '[ERROR] Key `{}` not found.'.format(key)
     else:
         for key in sorted(config):
-            print u'{0}={1}'.format(key, pipes.quote(config.get(key) or '')
+            print u'{0}={1}'.format(key, pipes.quote(config.get(key) or ''))


### PR DESCRIPTION
A re-jig of https://github.com/cloudControl/cctrl/pull/18 based on suggestions provided there.

This commit applies pipes.quote when outputting config variables so that the output is directly usable without awkward parsing.
