### PR TITLE
Update settings for platforms w/o user managemnt

### DIFF
--- a/cctrl/cnhuser
+++ b/cctrl/cnhuser
@@ -21,6 +21,10 @@ from cctrl.user_commands import setup_cli
 
 
 if __name__ == "__main__":
-    settings = Settings(api_url='https://api.cnh-apps.com', token_source_url="https://cctrl-tokenprovidermiddleware.cloudandheat.com/token",
-                        ssh_forwarder_url='sshforwarder.api.cnh-apps.com', encode_email=True)
+    settings = Settings(api_url='https://api.cnh-apps.com',
+                        token_source_url="https://cctrl-tokenprovidermiddleware.cloudandheat.com/token",
+                        ssh_forwarder_url='sshforwarder.api.cnh-apps.com',
+                        encode_email=True,
+                        user_registration_enabled=False,
+                        user_registration_url='https://www.cloudandheat.com')
     setup_cli(settings)

--- a/cctrl/error.py
+++ b/cctrl/error.py
@@ -73,6 +73,7 @@ messages['ClearCacheFailed'] = r'Clear buildpack cache failed.'
 messages['DeploymentFailed'] = r'Deployment failed.'
 messages['CommandNotImplemented'] = r'Sorry, this command is not available.'
 messages['ShipAndDeploy'] = r'--ship and --push options cannot be used simultaneously.'
+messages['RegisterDisabled'] = r'You can register on {}'
 
 if sys.platform == 'win32':
     messages['UpdateAvailable'] = r'A newer version is available. Please update.'

--- a/cctrl/settings.py
+++ b/cctrl/settings.py
@@ -26,9 +26,19 @@ CONFIG_ADDON = os.getenv('CONFIG_ADDON', 'config.free')
 
 
 class Settings(object):
-    def __init__(self, api_url=None, token_source_url=None, ssh_forwarder_url=None, env=os.environ, encode_email=False):
+    def __init__(self,
+                 api_url=None,
+                 token_source_url=None,
+                 ssh_forwarder_url=None,
+                 env=os.environ,
+                 encode_email=False,
+                 user_registration_enabled=True,
+                 user_registration_url='https://www.cloudcontrol.com'):
+
         self.ssh_forwarder = ssh_forwarder_url or env.get('SSH_FORWARDER', 'sshforwarder.cloudcontrolled.com')
         self.ssh_forwarder_port = '2222'
         self.api_url = api_url or env.get('CCTRL_API_URL', 'https://api.cloudcontrolled.com')
         self.token_source_url = token_source_url or self.api_url + '/token/'
         self.encode_email = encode_email
+        self.user_registration_enabled = user_registration_enabled
+        self.user_registration_url = user_registration_url

--- a/cctrl/user.py
+++ b/cctrl/user.py
@@ -30,15 +30,16 @@ from keyhelpers import is_key_valid, ask_user_to_use_default_ssh_public_key, \
 from pycclib import cclib
 
 
-class UserController():
+class UserController(object):
     """
         This controller handles all user related actions.
     """
 
     api = None
 
-    def __init__(self, api):
+    def __init__(self, api, settings):
         self.api = api
+        self.settings = settings
 
     def checktoken(self, args):
         try:
@@ -51,6 +52,10 @@ class UserController():
         """
             Create a new user.
         """
+        if not self.settings.user_registration_enabled:
+            print messages['RegisterDisabled'].format(self.settings.user_registration_url)
+            return
+
         self.api.set_token(None)
         if args.name and args.email and args.password:
             name = args.name[0]

--- a/cctrl/user_commands.py
+++ b/cctrl/user_commands.py
@@ -142,7 +142,7 @@ def parse_cmdline(user):
 def setup_cli(settings):
     api = common.init_api(settings)
     try:
-        user = UserController(api)
+        user = UserController(api, settings)
         parse_cmdline(user)
     except KeyboardInterrupt:
         pass

--- a/cctrl/version.py
+++ b/cctrl/version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '1.12.1'
+__version__ = '1.12.2'


### PR DESCRIPTION
Unfortunately not all platforms (cloud&heat for example) allow user
creation over the API and it's not possible to use
`cctrluser create ...` there.

Update the settings with a new flag `user_registration_enabled` and a
new property `user_registration_url` which can be used by cctrluser to
decide if it should allow the command or stop with a helpful error
message ("You can register on..").
