### PR TITLE
Adapt addon.add error message to the called cli

### DIFF
--- a/cctrl/error.py
+++ b/cctrl/error.py
@@ -15,6 +15,7 @@
     limitations under the License.
 """
 
+import os
 import sys
 
 messages = {}
@@ -36,7 +37,7 @@ messages['PermissionDenied'] = r'You are not allowed to push to this repository.
 messages['SecurityQuestionDenied'] = r'Action canceled on user request.'
 messages['WrongAddon'] = r'This addon is unknown for this app_name/deployment_name.'
 messages['DuplicateAddon'] = r'You can not add the same addon option twice.'
-messages['InvalidAddon'] = r'This is not a valid addon name. Check the list of available addons with cctrlapp app_name/deployment_name addon.list'
+messages['InvalidAddon'] = r'This is not a valid addon name. Check the list of available addons with {} app_name/deployment_name addon.list'.format(os.path.basename(sys.argv[0]))
 messages['ForbiddenAddon'] = 'You are not allowed to perform this action.\nIf you are trying to use a Beta addon, you can request access from the addon page.'
 messages['WrongPubKeyName'] = r'The public key file must be named "id_rsa.pub".'
 messages['NoSuchKeyFile'] = r'No such key file. Please check your input.'


### PR DESCRIPTION
The InvalidAddon error message had hard coded 'cctrlapp'. For cloud&heat,
exoscale and dotcloudapp we need different names. Reading the basename from
the sys.argv should solve this.
