### PR TITLE
Add cnhuser addon.register

### DIFF
--- a/cctrl/cnhuser
+++ b/cctrl/cnhuser
@@ -26,5 +26,6 @@ if __name__ == "__main__":
                         ssh_forwarder_url='sshforwarder.api.cnh-apps.com',
                         encode_email=True,
                         user_registration_enabled=False,
-                        user_registration_url='https://www.cloudandheat.com')
+                        user_registration_url='https://www.cloudandheat.com',
+                        register_addon_url='https://cctrl-tokenprovidermiddleware.cloudandheat.com')
     setup_cli(settings)

--- a/cctrl/common.py
+++ b/cctrl/common.py
@@ -65,7 +65,17 @@ def init_api(settings):
             break
 
         dirname = os.path.dirname(dirname)
-    return cclib.API(token=read_tokenfile(), url=settings.api_url, token_source_url=settings.token_source_url, encode_email=settings.encode_email)
+    return cclib.API(token=read_tokenfile(), url=settings.api_url, token_source_url=settings.token_source_url, register_addon_url=settings.register_addon_url, encode_email=settings.encode_email)
+
+
+def get_email_and_password():
+    # check ENV for credentials first
+    try:
+        email = os.environ.pop('CCTRL_EMAIL')
+        password = os.environ.pop('CCTRL_PASSWORD')
+    except KeyError:
+        email, password = get_credentials()
+    return email, password
 
 
 def execute_with_authenticated_user(api, command):
@@ -74,12 +84,7 @@ def execute_with_authenticated_user(api, command):
             try:
                 command()
             except (cclib.TokenRequiredError, cclib.UnauthorizedError):
-                # check ENV for credentials first
-                try:
-                    email = os.environ.pop('CCTRL_EMAIL')
-                    password = os.environ.pop('CCTRL_PASSWORD')
-                except KeyError:
-                    email, password = get_credentials()
+                email, password = get_email_and_password()
                 try:
                     api.create_token(email, password)
                 except cclib.UnauthorizedError:

--- a/cctrl/settings.py
+++ b/cctrl/settings.py
@@ -33,7 +33,8 @@ class Settings(object):
                  env=os.environ,
                  encode_email=False,
                  user_registration_enabled=True,
-                 user_registration_url='https://www.cloudcontrol.com'):
+                 user_registration_url='https://www.cloudcontrol.com',
+                 register_addon_url=None):
 
         self.ssh_forwarder = ssh_forwarder_url or env.get('SSH_FORWARDER', 'sshforwarder.cloudcontrolled.com')
         self.ssh_forwarder_port = '2222'
@@ -42,3 +43,4 @@ class Settings(object):
         self.encode_email = encode_email
         self.user_registration_enabled = user_registration_enabled
         self.user_registration_url = user_registration_url
+        self.register_addon_url = register_addon_url

--- a/cctrl/user.py
+++ b/cctrl/user.py
@@ -17,6 +17,7 @@
 
 import os
 import sys
+import json
 
 from cctrl.error import PasswordsDontMatchException, InputErrorException, messages
 from cctrl.auth import get_credentials
@@ -28,6 +29,7 @@ from oshelpers import readContentOf
 from keyhelpers import is_key_valid, ask_user_to_use_default_ssh_public_key, \
     create_new_default_ssh_keys
 from pycclib import cclib
+from cctrl.common import get_email_and_password
 
 
 class UserController(object):
@@ -187,3 +189,8 @@ class UserController(object):
             Logout a user by deleting the token.json file.
         """
         self.api.set_token(None)
+
+    def registerAddon(self, args):
+        file_content = readContentOf(args.manifest)
+        email, password = get_email_and_password()
+        self.api.register_addon(email, password, json.loads(file_content))

--- a/cctrl/user_commands.py
+++ b/cctrl/user_commands.py
@@ -134,6 +134,12 @@ def parse_cmdline(user):
     check_token_subparser = subparsers.add_parser('checktoken')
     check_token_subparser.set_defaults(func=user.checktoken)
 
+    registerAddon_subparser = subparsers.add_parser('addon.register', help="registers an addon")
+    registerAddon_subparser.add_argument(
+        'manifest',
+        help='path to the manifest file')
+    registerAddon_subparser.set_defaults(func=user.registerAddon)
+
     args = parser.parse_args()
 
     common.run(args, user.api)

--- a/cctrl/version.py
+++ b/cctrl/version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '1.12.2'
+__version__ = '1.13.0'


### PR DESCRIPTION
Whitelabel partner provide a middleware for addon registration. This
enables the whitelabel partner to handle the authentication and forwards
the manifest content to the cloudControl API.
E.g. cloud&heat have a special login (tenant_name:email), this breaks
the kensa tool.
Introducing addon.register simplifies the onboarding process for addon
providers.
