### PR TITLE
Prompt for updating right package when old version

### DIFF
--- a/cctrl/app_commands.py
+++ b/cctrl/app_commands.py
@@ -44,7 +44,7 @@ class list_action(argparse.Action):
 
     def __call__(self, parser, namespace, value, option_string=None):
         try:
-            common.check_for_updates(self.api.check_versions()['cctrl'])
+            common.check_for_updates(self.settings.package_name, self.api.check_versions()['cctrl'])
         except KeyError:
             pass
         except ConnectionException:

--- a/cctrl/cnhapp
+++ b/cctrl/cnhapp
@@ -29,5 +29,6 @@ if __name__ == "__main__":
                         user_registration_enabled=False,
                         user_registration_url='https://www.cloudandheat.com',
                         register_addon_url='https://cctrl-tokenprovidermiddleware.cloudandheat.com',
-                        login_name='Login   : ')
+                        login_name='Login   : ',
+                        package_name='cnh')
     setup_cli(settings)

--- a/cctrl/cnhuser
+++ b/cctrl/cnhuser
@@ -28,5 +28,6 @@ if __name__ == "__main__":
                         user_registration_enabled=False,
                         user_registration_url='https://www.cloudandheat.com',
                         register_addon_url='https://cctrl-tokenprovidermiddleware.cloudandheat.com',
-                        login_name='Login   : ')
+                        login_name='Login   : ',
+                        package_name='cnh')
     setup_cli(settings)

--- a/cctrl/common.py
+++ b/cctrl/common.py
@@ -26,7 +26,7 @@ from cctrl.auth import get_credentials, update_tokenfile, delete_tokenfile, read
 from cctrl.app import ParseAppDeploymentName
 
 
-def check_for_updates(latest_version_str, our_version_str=VERSION):
+def check_for_updates(package_name, latest_version_str, our_version_str=VERSION):
     """
         check if the API reports a version that is greater then our currently
         installed one
@@ -42,9 +42,9 @@ def check_for_updates(latest_version_str, our_version_str=VERSION):
     for part in ['major', 'minor', 'patch', 'suffix']:
         if latest[part] > our[part]:
             if part == 'major':
-                sys.exit(messages['UpdateRequired'])
+                sys.exit(messages['UpdateRequired'].format(package_name))
             else:
-                print >> sys.stderr, messages['UpdateAvailable']
+                print >> sys.stderr, messages['UpdateAvailable'].format(package_name)
             return
 
 

--- a/cctrl/dcapp
+++ b/cctrl/dcapp
@@ -22,5 +22,7 @@ from cctrl.app_commands import setup_cli
 
 
 if __name__ == "__main__":
-    settings = Settings(api_url='https://api.dotcloudapp.com', ssh_forwarder_url='sshforwarder.dotcloudapp.com')
+    settings = Settings(api_url='https://api.dotcloudapp.com',
+                        ssh_forwarder_url='sshforwarder.dotcloudapp.com',
+                        package_name='dotcloudng')
     setup_cli(settings)

--- a/cctrl/dcuser
+++ b/cctrl/dcuser
@@ -21,5 +21,7 @@ from cctrl.user_commands import setup_cli
 
 
 if __name__ == "__main__":
-    settings = Settings(api_url='https://api.dotcloudapp.com', ssh_forwarder_url='sshforwarder.dotcloudapp.com')
+    settings = Settings(api_url='https://api.dotcloudapp.com',
+                        ssh_forwarder_url='sshforwarder.dotcloudapp.com',
+                        package_name='dotcloudng')
     setup_cli(settings)

--- a/cctrl/error.py
+++ b/cctrl/error.py
@@ -80,8 +80,8 @@ if sys.platform == 'win32':
     messages['UpdateAvailable'] = r'A newer version is available. Please update.'
     messages['UpdateRequired'] = r'A newer version is required. You need to upgrade before using this program.'
 else:
-    messages['UpdateAvailable'] = r'A newer version is available. To upgrade run: (sudo) pip install cctrl --upgrade'
-    messages['UpdateRequired'] = r'A newer version is required. You need to upgrade before using this program. To upgrade run: (sudo) pip install cctrl --upgrade'
+    messages['UpdateAvailable'] = r'A newer version is available. To upgrade run: (sudo) pip install {} --upgrade'
+    messages['UpdateRequired'] = r'A newer version is required. You need to upgrade before using this program. To upgrade run: (sudo) pip install {} --upgrade'
 
 
 class InputErrorException(Exception):

--- a/cctrl/settings.py
+++ b/cctrl/settings.py
@@ -35,7 +35,8 @@ class Settings(object):
                  user_registration_enabled=True,
                  user_registration_url='https://www.cloudcontrol.com',
                  register_addon_url=None,
-                 login_name='Email   : '):
+                 login_name='Email   : ',
+                 package_name='cctrl'):
 
         self.ssh_forwarder = ssh_forwarder_url or env.get('SSH_FORWARDER', 'sshforwarder.cloudcontrolled.com')
         self.ssh_forwarder_port = '2222'
@@ -46,3 +47,4 @@ class Settings(object):
         self.user_registration_url = user_registration_url
         self.register_addon_url = register_addon_url
         self.login_name = login_name
+        self.package_name = package_name

--- a/cctrl/version.py
+++ b/cctrl/version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '1.13.1'
+__version__ = '1.13.2'

--- a/win32/wininstaller_cctrl.iss
+++ b/win32/wininstaller_cctrl.iss
@@ -7,7 +7,7 @@
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
 AppId={{86DDE49A-CB27-4B64-A816-887A13C06D58}
 AppName=cctrl
-AppVerName=cctrl-1.12.1
+AppVerName=cctrl-1.13.2
 AppPublisher=cloudControl GmbH
 AppPublisherURL=https://www.cloudcontrol.com
 AppSupportURL=https://www.cloudcontrol.com
@@ -17,7 +17,7 @@ DefaultGroupName=cloudControl
 AllowNoIcons=yes
 SourceDir=..\
 OutputDir=win32setup
-OutputBaseFilename=cctrl-1.12.1-setup
+OutputBaseFilename=cctrl-1.13.2-setup
 Compression=lzma
 SolidCompression=yes
 ChangesEnvironment=yes

--- a/win32/wininstaller_cnh.iss
+++ b/win32/wininstaller_cnh.iss
@@ -7,7 +7,7 @@
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
 AppId={{86DDE49A-CB27-4B64-A816-887A13C06D58}
 AppName=cnh
-AppVerName=cnh-1.12.1
+AppVerName=cnh-1.13.2
 AppPublisher=cloudControl GmbH
 AppPublisherURL=https://www.cloudcontrol.com
 AppSupportURL=https://www.cloudcontrol.com
@@ -17,7 +17,7 @@ DefaultGroupName=cnh
 AllowNoIcons=yes
 SourceDir=..\
 OutputDir=win32setup
-OutputBaseFilename=cnh-1.12.1-setup
+OutputBaseFilename=cnh-1.13.2-setup
 Compression=lzma
 SolidCompression=yes
 ChangesEnvironment=yes

--- a/win32/wininstaller_dotcloudng.iss
+++ b/win32/wininstaller_dotcloudng.iss
@@ -7,7 +7,7 @@
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
 AppId={{86DDE49A-CB27-4B64-A816-887A13C06D58}
 AppName=dotcloudng
-AppVerName=dotcloudng-1.12.1
+AppVerName=dotcloudng-1.13.2
 AppPublisher=cloudControl Inc.
 AppPublisherURL=https://www.dotcloud.com
 AppSupportURL=https://www.dotcloud.com
@@ -17,7 +17,7 @@ DefaultGroupName=dotcloud
 AllowNoIcons=yes
 SourceDir=..\
 OutputDir=win32setup
-OutputBaseFilename=dotcloudng-1.12.1-setup
+OutputBaseFilename=dotcloudng-1.13.2-setup
 Compression=lzma
 SolidCompression=yes
 ChangesEnvironment=yes


### PR DESCRIPTION
Fixes #33

Previously this was hardcoded, so the user always got a message to upgrade
`cctrl` regardless of which package where they using.

This still checks the version of `cctrl` package (via api), but ideally this
should equal the ones from dotcloudng, cnh or another clones.
