### PR TITLE
Make the login prompt configurable

### DIFF
--- a/cctrl/app_commands.py
+++ b/cctrl/app_commands.py
@@ -37,9 +37,10 @@ class list_action(argparse.Action):
         It would be better to use common.run here too.
     """
 
-    def __init__(self, api, **kwargs):
+    def __init__(self, api, settings, **kwargs):
         super(list_action, self).__init__(**kwargs)
         self.api = api
+        self.settings = settings
 
     def __call__(self, parser, namespace, value, option_string=None):
         try:
@@ -50,7 +51,7 @@ class list_action(argparse.Action):
             pass
 
         apps = AppsController(self.api)
-        common.execute_with_authenticated_user(self.api, lambda: apps.list())
+        common.execute_with_authenticated_user(self.api, lambda: apps.list(), self.settings)
         parser.exit()
 
 
@@ -82,6 +83,7 @@ def parse_cmdline(app):
         action=list_action,
         nargs=0,
         api=app.api,
+        settings=app.settings,
         help='list apps')
 
     control_apps = parser.add_argument_group(
@@ -459,7 +461,7 @@ def parse_cmdline(app):
 
     args = parser.parse_args()
 
-    common.run(args, app.api)
+    common.run(args, app.api, app.settings)
 
 
 def setup_cli(settings):

--- a/cctrl/auth.py
+++ b/cctrl/auth.py
@@ -93,7 +93,7 @@ def delete_tokenfile():
     return False
 
 
-def get_credentials(create=False):
+def get_credentials(settings, create=False):
     """
         We use this to ask the user for his credentials in case we have no
         valid token.
@@ -101,7 +101,7 @@ def get_credentials(create=False):
         to make sure, that no typing error occurred. This is done three times
         after that a PasswordsDontMatchException is thrown.
     """
-    sys.stderr.write('Email   : ')
+    sys.stderr.write(settings.login_name)
     sys.stderr.flush()
     email = raw_input()
     password = None

--- a/cctrl/cnhapp
+++ b/cctrl/cnhapp
@@ -22,6 +22,12 @@ from cctrl.app_commands import setup_cli
 
 
 if __name__ == "__main__":
-    settings = Settings(api_url='https://api.cnh-apps.com', token_source_url="https://cctrl-tokenprovidermiddleware.cloudandheat.com/token",
-                        ssh_forwarder_url='sshforwarder.api.cnh-apps.com', encode_email=True)
+    settings = Settings(api_url='https://api.cnh-apps.com',
+                        token_source_url="https://cctrl-tokenprovidermiddleware.cloudandheat.com/token",
+                        ssh_forwarder_url='sshforwarder.api.cnh-apps.com',
+                        encode_email=True,
+                        user_registration_enabled=False,
+                        user_registration_url='https://www.cloudandheat.com',
+                        register_addon_url='https://cctrl-tokenprovidermiddleware.cloudandheat.com',
+                        login_name='Login   : ')
     setup_cli(settings)

--- a/cctrl/cnhuser
+++ b/cctrl/cnhuser
@@ -27,5 +27,6 @@ if __name__ == "__main__":
                         encode_email=True,
                         user_registration_enabled=False,
                         user_registration_url='https://www.cloudandheat.com',
-                        register_addon_url='https://cctrl-tokenprovidermiddleware.cloudandheat.com')
+                        register_addon_url='https://cctrl-tokenprovidermiddleware.cloudandheat.com',
+                        login_name='Login   : ')
     setup_cli(settings)

--- a/cctrl/common.py
+++ b/cctrl/common.py
@@ -68,23 +68,23 @@ def init_api(settings):
     return cclib.API(token=read_tokenfile(), url=settings.api_url, token_source_url=settings.token_source_url, register_addon_url=settings.register_addon_url, encode_email=settings.encode_email)
 
 
-def get_email_and_password():
+def get_email_and_password(settings):
     # check ENV for credentials first
     try:
         email = os.environ.pop('CCTRL_EMAIL')
         password = os.environ.pop('CCTRL_PASSWORD')
     except KeyError:
-        email, password = get_credentials()
+        email, password = get_credentials(settings)
     return email, password
 
 
-def execute_with_authenticated_user(api, command):
+def execute_with_authenticated_user(api, command, settings):
     while True:
         try:
             try:
                 command()
             except (cclib.TokenRequiredError, cclib.UnauthorizedError):
-                email, password = get_email_and_password()
+                email, password = get_email_and_password(settings)
                 try:
                     api.create_token(email, password)
                 except cclib.UnauthorizedError:
@@ -105,7 +105,7 @@ def execute_with_authenticated_user(api, command):
             sys.exit(e)
 
 
-def run(args, api):
+def run(args, api, settings):
     """
         run takes care of calling the action with the needed arguments parsed
         using argparse.
@@ -122,7 +122,7 @@ def run(args, api):
         user.
     """
 
-    execute_with_authenticated_user(api, (lambda: args.func(args)))
+    execute_with_authenticated_user(api, (lambda: args.func(args)), settings)
 
 
 def shutdown(api):

--- a/cctrl/exoapp
+++ b/cctrl/exoapp
@@ -22,6 +22,8 @@ from cctrl.app_commands import setup_cli
 
 
 if __name__ == "__main__":
-    settings = Settings(api_url='https://api.app.exo.io', token_source_url="https://portal.exoscale.ch/api/apps/token",
-                        ssh_forwarder_url='sshforwarder.app.exo.io')
+    settings = Settings(api_url='https://api.app.exo.io',
+                        token_source_url="https://portal.exoscale.ch/api/apps/token",
+                        ssh_forwarder_url='sshforwarder.app.exo.io',
+                        login_name='Email or Organization ID: ')
     setup_cli(settings)

--- a/cctrl/exouser
+++ b/cctrl/exouser
@@ -16,11 +16,14 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
+
 from cctrl.settings import Settings
 from cctrl.user_commands import setup_cli
 
 
 if __name__ == "__main__":
-    settings = Settings(api_url='https://api.app.exo.io', token_source_url="https://portal.exoscale.ch/api/apps/token",
-                        ssh_forwarder_url='sshforwarder.app.exo.io')
+    settings = Settings(api_url='https://api.app.exo.io',
+                        token_source_url="https://portal.exoscale.ch/api/apps/token",
+                        ssh_forwarder_url='sshforwarder.app.exo.io',
+                        login_name='Email or Organization ID: ')
     setup_cli(settings)

--- a/cctrl/settings.py
+++ b/cctrl/settings.py
@@ -34,7 +34,8 @@ class Settings(object):
                  encode_email=False,
                  user_registration_enabled=True,
                  user_registration_url='https://www.cloudcontrol.com',
-                 register_addon_url=None):
+                 register_addon_url=None,
+                 login_name='Email   : '):
 
         self.ssh_forwarder = ssh_forwarder_url or env.get('SSH_FORWARDER', 'sshforwarder.cloudcontrolled.com')
         self.ssh_forwarder_port = '2222'
@@ -44,3 +45,4 @@ class Settings(object):
         self.user_registration_enabled = user_registration_enabled
         self.user_registration_url = user_registration_url
         self.register_addon_url = register_addon_url
+        self.login_name = login_name

--- a/cctrl/user.py
+++ b/cctrl/user.py
@@ -66,7 +66,7 @@ class UserController(object):
         else:
             name = raw_input('Username: ')
             try:
-                email, password = get_credentials(create=True)
+                email, password = get_credentials(self.settings, create=True)
             except PasswordsDontMatchException:
                 return
         try:
@@ -192,5 +192,5 @@ class UserController(object):
 
     def registerAddon(self, args):
         file_content = readContentOf(args.manifest)
-        email, password = get_email_and_password()
+        email, password = get_email_and_password(self.settings)
         self.api.register_addon(email, password, json.loads(file_content))

--- a/cctrl/user_commands.py
+++ b/cctrl/user_commands.py
@@ -142,7 +142,7 @@ def parse_cmdline(user):
 
     args = parser.parse_args()
 
-    common.run(args, user.api)
+    common.run(args, user.api, user.settings)
 
 
 def setup_cli(settings):


### PR DESCRIPTION
The different platforms use different kind of logins:
- cloudcontrolled uses 'Email'
- dotcloudapp uses 'Email'
- app.exo.io uses 'Email or Organization ID'
- cnh-apps uses 'Login'

Especially on cloud&heat the login is a combination of tenant_name
and email. Asking only for the email confuses the customers (and me).
