### PR TITLE
Catch exception on addon.register

### DIFF
--- a/cctrl/user.py
+++ b/cctrl/user.py
@@ -193,4 +193,13 @@ class UserController(object):
     def registerAddon(self, args):
         file_content = readContentOf(args.manifest)
         email, password = get_email_and_password(self.settings)
-        self.api.register_addon(email, password, json.loads(file_content))
+        try:
+            self.api.register_addon(email, password, json.loads(file_content))
+        except cclib.UnauthorizedError:
+            sys.exit(messages['NotAuthorized'])
+        except cclib.ForbiddenError, e:
+            sys.exit(messages['NotAllowed'])
+        except cclib.ConnectionException:
+            sys.exit(messages['APIUnreachable'])
+        except Exception as e:
+            sys.exit(e)

--- a/cctrl/version.py
+++ b/cctrl/version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '1.13.0'
+__version__ = '1.13.1'


### PR DESCRIPTION
Exceptions are handled by the common.execute_with_authenticated_user.
If you add type in wrong email and password you are asked again, but
the request is send to /token, which is wrong. By catching the exception
and exiting this is solved.
