### PR TITLE
Read dedicated login creds for each platform

### DIFF
--- a/cctrl/cnhapp
+++ b/cctrl/cnhapp
@@ -30,5 +30,7 @@ if __name__ == "__main__":
                         user_registration_url='https://www.cloudandheat.com',
                         register_addon_url='https://cctrl-tokenprovidermiddleware.cloudandheat.com',
                         login_name='Login   : ',
+                        login_creds={'email': 'CNH_EMAIL',
+                                     'pwd': 'CNH_PASSWORD'},
                         package_name='cnh')
     setup_cli(settings)

--- a/cctrl/cnhuser
+++ b/cctrl/cnhuser
@@ -29,5 +29,7 @@ if __name__ == "__main__":
                         user_registration_url='https://www.cloudandheat.com',
                         register_addon_url='https://cctrl-tokenprovidermiddleware.cloudandheat.com',
                         login_name='Login   : ',
+                        login_creds={'email': 'CNH_EMAIL',
+                                     'pwd': 'CNH_PASSWORD'},
                         package_name='cnh')
     setup_cli(settings)

--- a/cctrl/common.py
+++ b/cctrl/common.py
@@ -65,14 +65,18 @@ def init_api(settings):
             break
 
         dirname = os.path.dirname(dirname)
-    return cclib.API(token=read_tokenfile(), url=settings.api_url, token_source_url=settings.token_source_url, register_addon_url=settings.register_addon_url, encode_email=settings.encode_email)
+    return cclib.API(token=read_tokenfile(),
+                     url=settings.api_url,
+                     token_source_url=settings.token_source_url,
+                     register_addon_url=settings.register_addon_url,
+                     encode_email=settings.encode_email)
 
 
 def get_email_and_password(settings):
     # check ENV for credentials first
     try:
-        email = os.environ.pop('CCTRL_EMAIL')
-        password = os.environ.pop('CCTRL_PASSWORD')
+        email = os.environ.pop(settings.login_creds['email'])
+        password = os.environ.pop(settings.login_creds['pwd'])
     except KeyError:
         email, password = get_credentials(settings)
     return email, password

--- a/cctrl/dcapp
+++ b/cctrl/dcapp
@@ -24,5 +24,7 @@ from cctrl.app_commands import setup_cli
 if __name__ == "__main__":
     settings = Settings(api_url='https://api.dotcloudapp.com',
                         ssh_forwarder_url='sshforwarder.dotcloudapp.com',
+                        login_creds={'email': 'DC_EMAIL',
+                                     'pwd': 'DC_PASSWORD'},
                         package_name='dotcloudng')
     setup_cli(settings)

--- a/cctrl/dcuser
+++ b/cctrl/dcuser
@@ -23,5 +23,7 @@ from cctrl.user_commands import setup_cli
 if __name__ == "__main__":
     settings = Settings(api_url='https://api.dotcloudapp.com',
                         ssh_forwarder_url='sshforwarder.dotcloudapp.com',
+                        login_creds={'email': 'DC_EMAIL',
+                                     'pwd': 'DC_PASSWORD'},
                         package_name='dotcloudng')
     setup_cli(settings)

--- a/cctrl/exoapp
+++ b/cctrl/exoapp
@@ -25,5 +25,7 @@ if __name__ == "__main__":
     settings = Settings(api_url='https://api.app.exo.io',
                         token_source_url="https://portal.exoscale.ch/api/apps/token",
                         ssh_forwarder_url='sshforwarder.app.exo.io',
-                        login_name='Email or Organization ID: ')
+                        login_name='Email or Organization ID: ',
+                        login_creds={'email': 'EXO_EMAIL',
+                                     'pwd': 'EXO_PASSWORD'})
     setup_cli(settings)

--- a/cctrl/exouser
+++ b/cctrl/exouser
@@ -26,5 +26,7 @@ if __name__ == "__main__":
                         token_source_url="https://portal.exoscale.ch/api/apps/token",
                         ssh_forwarder_url='sshforwarder.app.exo.io',
                         register_addon_url='https://portal.exoscale.ch',
-                        login_name='Email or Organization ID: ')
+                        login_name='Email or Organization ID: ',
+                        login_creds={'email': 'EXO_EMAIL',
+                                     'pwd': 'EXO_PASSWORD'})
     setup_cli(settings)

--- a/cctrl/settings.py
+++ b/cctrl/settings.py
@@ -36,6 +36,8 @@ class Settings(object):
                  user_registration_url='https://www.cloudcontrol.com',
                  register_addon_url=None,
                  login_name='Email   : ',
+                 login_creds={'email': 'CCTRL_EMAIL',
+                              'pwd': 'CCTRL_PASSWORD'},
                  package_name='cctrl'):
 
         self.ssh_forwarder = ssh_forwarder_url or env.get('SSH_FORWARDER', 'sshforwarder.cloudcontrolled.com')
@@ -47,4 +49,5 @@ class Settings(object):
         self.user_registration_url = user_registration_url
         self.register_addon_url = register_addon_url
         self.login_name = login_name
+        self.login_creds = login_creds
         self.package_name = package_name

--- a/cctrl/version.py
+++ b/cctrl/version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '1.13.3'
+__version__ = '1.14.0'

--- a/win32/wininstaller_cctrl.iss
+++ b/win32/wininstaller_cctrl.iss
@@ -7,7 +7,7 @@
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
 AppId={{86DDE49A-CB27-4B64-A816-887A13C06D58}
 AppName=cctrl
-AppVerName=cctrl-1.13.2
+AppVerName=cctrl-1.14.0
 AppPublisher=cloudControl GmbH
 AppPublisherURL=https://www.cloudcontrol.com
 AppSupportURL=https://www.cloudcontrol.com
@@ -17,7 +17,7 @@ DefaultGroupName=cloudControl
 AllowNoIcons=yes
 SourceDir=..\
 OutputDir=win32setup
-OutputBaseFilename=cctrl-1.13.2-setup
+OutputBaseFilename=cctrl-1.14.0-setup
 Compression=lzma
 SolidCompression=yes
 ChangesEnvironment=yes

--- a/win32/wininstaller_cnh.iss
+++ b/win32/wininstaller_cnh.iss
@@ -7,7 +7,7 @@
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
 AppId={{86DDE49A-CB27-4B64-A816-887A13C06D58}
 AppName=cnh
-AppVerName=cnh-1.13.2
+AppVerName=cnh-1.14.0
 AppPublisher=cloudControl GmbH
 AppPublisherURL=https://www.cloudcontrol.com
 AppSupportURL=https://www.cloudcontrol.com
@@ -17,7 +17,7 @@ DefaultGroupName=cnh
 AllowNoIcons=yes
 SourceDir=..\
 OutputDir=win32setup
-OutputBaseFilename=cnh-1.13.2-setup
+OutputBaseFilename=cnh-1.14.0-setup
 Compression=lzma
 SolidCompression=yes
 ChangesEnvironment=yes

--- a/win32/wininstaller_dotcloudng.iss
+++ b/win32/wininstaller_dotcloudng.iss
@@ -7,7 +7,7 @@
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
 AppId={{86DDE49A-CB27-4B64-A816-887A13C06D58}
 AppName=dotcloudng
-AppVerName=dotcloudng-1.13.2
+AppVerName=dotcloudng-1.14.0
 AppPublisher=cloudControl Inc.
 AppPublisherURL=https://www.dotcloud.com
 AppSupportURL=https://www.dotcloud.com
@@ -17,7 +17,7 @@ DefaultGroupName=dotcloud
 AllowNoIcons=yes
 SourceDir=..\
 OutputDir=win32setup
-OutputBaseFilename=dotcloudng-1.13.2-setup
+OutputBaseFilename=dotcloudng-1.14.0-setup
 Compression=lzma
 SolidCompression=yes
 ChangesEnvironment=yes


### PR DESCRIPTION
Previously we read the hardcoded `CCTRL_EMAIL`
and `CCTRL_PASSWORD` env variables as login credentials.

This introduces dedicated envs for login into exoscale, dotcloudng
or cnh platforms.

exoscale -> EXO_EMAIL, EXO_PASSWORD
dotcloudng -> DC_EMAIL, DC_PASSWORD
cnh -> CNH_EMAIL, CNH_PASSWORD
