### PR TITLE
Improvements for config.add command

### DIFF
--- a/cctrl/addonoptionhelpers.py
+++ b/cctrl/addonoptionhelpers.py
@@ -21,6 +21,7 @@ from os import path
 import re
 import json
 from cctrl.oshelpers import recode_input
+from cctrl.error import InputErrorException
 
 
 def if_file_get_content(value):
@@ -79,3 +80,17 @@ def parse_config_variables(variables, method):
                 result[var.strip()] = 'true'
 
     return json.dumps(result)
+
+
+def extract_flag_from_variables(variables, flag_names, flag_value):
+    flag_found = False
+
+    for flag_name in flag_names:
+        if flag_name in variables:
+            variables.remove(flag_name)
+            flag_found = True
+
+    if flag_value and flag_found:
+        raise InputErrorException('DuplicatedFlag')
+
+    return variables, flag_value or flag_found

--- a/cctrl/app.py
+++ b/cctrl/app.py
@@ -42,7 +42,8 @@ from cctrl.output import print_deployment_details, print_app_details,\
     print_worker_list, print_worker_details, print_cronjob_list, \
     print_cronjob_details, print_addon_creds, print_config
 from output import print_user_list_app, print_user_list_deployment
-from cctrl.addonoptionhelpers import parse_additional_addon_options, parse_config_variables
+from cctrl.addonoptionhelpers import parse_additional_addon_options, \
+    parse_config_variables, extract_flag_from_variables
 
 
 class AppsController():
@@ -738,8 +739,11 @@ class AppController():
         if not args.variables:
             raise InputErrorException('NoVariablesGiven')
 
-        variables = parse_config_variables(args.variables, 'add')
-        force = args.force_add
+        args_variables, force = extract_flag_from_variables(args.variables,
+                                                            ('-f', '--force'),
+                                                            args.force_add)
+
+        variables = parse_config_variables(args_variables, 'add')
 
         try:
             self.api.update_addon(

--- a/cctrl/error.py
+++ b/cctrl/error.py
@@ -76,6 +76,7 @@ messages['CommandNotImplemented'] = r'Sorry, this command is not available.'
 messages['ShipAndDeploy'] = r'--ship and --push options cannot be used simultaneously.'
 messages['RegisterDisabled'] = r'You can register on {}.'
 messages['NoVariablesGiven'] = r'You must provide some variables.'
+messages['DuplicatedFlag'] = r'Please, specify a flag only once.'
 
 if sys.platform == 'win32':
     messages['UpdateAvailable'] = r'A newer version is available. Please update.'

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,0 +1,79 @@
+import unittest
+
+from mock import patch, Mock
+
+from cctrl.app import AppController
+from cctrl.error import InputErrorException
+from cctrl.settings import Settings
+
+
+class AppControllerTestCase(unittest.TestCase):
+    @patch('cctrl.app.parse_config_variables')
+    def test_add_config(self, parse_config_variables):
+        app = AppController(None, Settings())
+        app.api = Mock()
+        args = Mock()
+        args.name = 'app/dep'
+        args.force_add = False
+        args.variables = ['foo=bar']
+        app.addConfig(args)
+        self.assertTrue(parse_config_variables.called)
+        self.assertTrue(app.api.update_addon.called)
+
+    @patch('cctrl.app.parse_config_variables')
+    def test_add_config_force_flag(self, parse_config_variables):
+        app = AppController(None, Settings())
+        app.api = Mock()
+        args = Mock()
+        args.name = 'app/dep'
+        args.force_add = True
+        args.variables = ['foo=bar']
+        app.addConfig(args)
+        self.assertTrue(parse_config_variables.called)
+        self.assertTrue(app.api.update_addon.called)
+
+    @patch('cctrl.app.parse_config_variables')
+    def test_add_config_force_arg(self, parse_config_variables):
+        app = AppController(None, Settings())
+        app.api = Mock()
+        args = Mock()
+        args.name = 'app/dep'
+        args.force_add = False
+        args.variables = ['foo=bar', '--force']
+        app.addConfig(args)
+        self.assertTrue(parse_config_variables.called)
+        self.assertTrue(app.api.update_addon.called)
+
+    @patch('cctrl.app.parse_config_variables')
+    def test_add_config_no_variables_given(self, parse_config_variables):
+        app = AppController(None, Settings())
+        app.api = Mock()
+        args = Mock()
+        args.name = 'app/dep'
+        args.force_add = False
+        args.variables = None
+        with self.assertRaises(InputErrorException) as nvg:
+            app.addConfig(args)
+
+        self.assertEqual(
+            '[ERROR] You must provide some variables.',
+            str(nvg.exception))
+        self.assertFalse(parse_config_variables.called)
+        self.assertFalse(app.api.update_addon.called)
+
+    @patch('cctrl.app.parse_config_variables')
+    def test_add_config_duplicated_flag(self, parse_config_variables):
+        app = AppController(None, Settings())
+        app.api = Mock()
+        args = Mock()
+        args.name = 'app/dep'
+        args.force_add = True
+        args.variables = ['foo=bar', '-f']
+        with self.assertRaises(InputErrorException) as df:
+            app.addConfig(args)
+
+        self.assertEqual(
+            '[ERROR] Please, specify a flag only once.',
+            str(df.exception))
+        self.assertFalse(parse_config_variables.called)
+        self.assertFalse(app.api.update_addon.called)


### PR DESCRIPTION
- Add output message for NoVariablesGiven error
- Allow multipositional force flag
  Furthermore, it disallows having duplicated force
  flags.
  
  Fixes #41. See this issue for more details.
