### PR TITLE
Prefix user invation with project name

### DIFF
--- a/cctrl/app.py
+++ b/cctrl/app.py
@@ -926,9 +926,15 @@ class AppController():
 
     def addUser(self, args):
         """
-            Add a user specified by the e-mail address to an application.
+            Add a user specified by the e-mail address to an application or deployment.
         """
         app_name, deployment_name = self.parse_app_deployment_name(args.name)
+
+        if self.settings.prefix_project_name:
+            if len(args.email.split(':')) != 2:
+                prefix = self.api.read_users()[0]['email'].split(':')[0]
+                args.email = '{}:{}'.format(prefix, args.email)
+
         try:
             if deployment_name:
                 self.api.create_deployment_user(app_name, deployment_name, args.email, args.role)
@@ -944,7 +950,7 @@ class AppController():
 
     def removeUser(self, args):
         """
-            Remove a user specified by the user name or email address from an application.
+            Remove a user specified by the user name or email address from an application or deployment.
         """
         app_name, deployment_name = self.parse_app_deployment_name(args.name)
         if '@' in args.username:

--- a/cctrl/cnhapp
+++ b/cctrl/cnhapp
@@ -32,5 +32,6 @@ if __name__ == "__main__":
                         login_name='Login   : ',
                         login_creds={'email': 'CNH_LOGIN',
                                      'pwd': 'CNH_PASSWORD'},
-                        package_name='cnh')
+                        package_name='cnh',
+                        prefix_project_name=True)
     setup_cli(settings)

--- a/cctrl/cnhuser
+++ b/cctrl/cnhuser
@@ -31,5 +31,6 @@ if __name__ == "__main__":
                         login_name='Login   : ',
                         login_creds={'email': 'CNH_LOGIN',
                                      'pwd': 'CNH_PASSWORD'},
-                        package_name='cnh')
+                        package_name='cnh',
+                        prefix_project_name=True)
     setup_cli(settings)

--- a/cctrl/settings.py
+++ b/cctrl/settings.py
@@ -38,7 +38,8 @@ class Settings(object):
                  login_name='Email   : ',
                  login_creds={'email': 'CCTRL_EMAIL',
                               'pwd': 'CCTRL_PASSWORD'},
-                 package_name='cctrl'):
+                 package_name='cctrl',
+                 prefix_project_name=False):
 
         self.ssh_forwarder = ssh_forwarder_url or env.get('SSH_FORWARDER', 'sshforwarder.cloudcontrolled.com')
         self.ssh_forwarder_port = '2222'
@@ -51,3 +52,4 @@ class Settings(object):
         self.login_name = login_name
         self.login_creds = login_creds
         self.package_name = package_name
+        self.prefix_project_name = prefix_project_name

--- a/cctrl/version.py
+++ b/cctrl/version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '1.14.1'
+__version__ = '1.14.2'

--- a/win32/wininstaller_cctrl.iss
+++ b/win32/wininstaller_cctrl.iss
@@ -7,7 +7,7 @@
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
 AppId={{86DDE49A-CB27-4B64-A816-887A13C06D58}
 AppName=cctrl
-AppVerName=cctrl-1.14.1
+AppVerName=cctrl-1.14.2
 AppPublisher=cloudControl GmbH
 AppPublisherURL=https://www.cloudcontrol.com
 AppSupportURL=https://www.cloudcontrol.com
@@ -17,7 +17,7 @@ DefaultGroupName=cloudControl
 AllowNoIcons=yes
 SourceDir=..\
 OutputDir=win32setup
-OutputBaseFilename=cctrl-1.14.1-setup
+OutputBaseFilename=cctrl-1.14.2-setup
 Compression=lzma
 SolidCompression=yes
 ChangesEnvironment=yes

--- a/win32/wininstaller_cnh.iss
+++ b/win32/wininstaller_cnh.iss
@@ -7,7 +7,7 @@
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
 AppId={{86DDE49A-CB27-4B64-A816-887A13C06D58}
 AppName=cnh
-AppVerName=cnh-1.14.1
+AppVerName=cnh-1.14.2
 AppPublisher=cloudControl GmbH
 AppPublisherURL=https://www.cloudcontrol.com
 AppSupportURL=https://www.cloudandheat.com
@@ -17,7 +17,7 @@ DefaultGroupName=cloudandheat
 AllowNoIcons=yes
 SourceDir=..\
 OutputDir=win32setup
-OutputBaseFilename=cnh-1.14.1-setup
+OutputBaseFilename=cnh-1.14.2-setup
 Compression=lzma
 SolidCompression=yes
 ChangesEnvironment=yes

--- a/win32/wininstaller_dotcloudng.iss
+++ b/win32/wininstaller_dotcloudng.iss
@@ -7,7 +7,7 @@
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
 AppId={{86DDE49A-CB27-4B64-A816-887A13C06D58}
 AppName=dotcloudng
-AppVerName=dotcloudng-1.14.1
+AppVerName=dotcloudng-1.14.2
 AppPublisher=cloudControl Inc.
 AppPublisherURL=https://www.dotcloud.com
 AppSupportURL=https://www.dotcloud.com
@@ -17,7 +17,7 @@ DefaultGroupName=dotcloud
 AllowNoIcons=yes
 SourceDir=..\
 OutputDir=win32setup
-OutputBaseFilename=dotcloudng-1.14.1-setup
+OutputBaseFilename=dotcloudng-1.14.2-setup
 Compression=lzma
 SolidCompression=yes
 ChangesEnvironment=yes


### PR DESCRIPTION
To simplify the process of inviting users on cloud&heat, the
provided e-mail address is prefixed with the project name of the
current user, if no project name is given.
The format needs to be <project name>:<email>
