### PR TITLE
Bump version 1.15.1

### DIFF
--- a/cctrl/version.py
+++ b/cctrl/version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '1.15.0'
+__version__ = '1.15.1'

--- a/win32/wininstaller_cctrl.iss
+++ b/win32/wininstaller_cctrl.iss
@@ -7,7 +7,7 @@
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
 AppId={{86DDE49A-CB27-4B64-A816-887A13C06D58}
 AppName=cctrl
-AppVerName=cctrl-1.15.0
+AppVerName=cctrl-1.15.1
 AppPublisher=cloudControl GmbH
 AppPublisherURL=https://www.cloudcontrol.com
 AppSupportURL=https://www.cloudcontrol.com
@@ -17,7 +17,7 @@ DefaultGroupName=cloudControl
 AllowNoIcons=yes
 SourceDir=..\
 OutputDir=win32setup
-OutputBaseFilename=cctrl-1.15.0-setup
+OutputBaseFilename=cctrl-1.15.1-setup
 Compression=lzma
 SolidCompression=yes
 ChangesEnvironment=yes

--- a/win32/wininstaller_cnh.iss
+++ b/win32/wininstaller_cnh.iss
@@ -7,7 +7,7 @@
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
 AppId={{86DDE49A-CB27-4B64-A816-887A13C06D58}
 AppName=cnh
-AppVerName=cnh-1.15.0
+AppVerName=cnh-1.15.1
 AppPublisher=cloudControl GmbH
 AppPublisherURL=https://www.cloudcontrol.com
 AppSupportURL=https://www.cloudandheat.com
@@ -17,7 +17,7 @@ DefaultGroupName=cloudandheat
 AllowNoIcons=yes
 SourceDir=..\
 OutputDir=win32setup
-OutputBaseFilename=cnh-1.15.0-setup
+OutputBaseFilename=cnh-1.15.1-setup
 Compression=lzma
 SolidCompression=yes
 ChangesEnvironment=yes

--- a/win32/wininstaller_dotcloudng.iss
+++ b/win32/wininstaller_dotcloudng.iss
@@ -7,7 +7,7 @@
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
 AppId={{86DDE49A-CB27-4B64-A816-887A13C06D58}
 AppName=dotcloudng
-AppVerName=dotcloudng-1.15.0
+AppVerName=dotcloudng-1.15.1
 AppPublisher=cloudControl Inc.
 AppPublisherURL=https://www.dotcloud.com
 AppSupportURL=https://www.dotcloud.com
@@ -17,7 +17,7 @@ DefaultGroupName=dotcloud
 AllowNoIcons=yes
 SourceDir=..\
 OutputDir=win32setup
-OutputBaseFilename=dotcloudng-1.15.0-setup
+OutputBaseFilename=dotcloudng-1.15.1-setup
 Compression=lzma
 SolidCompression=yes
 ChangesEnvironment=yes


### PR DESCRIPTION
Fixes:
* Make `cctrluser create` work due to a wrong
call of `get_email` method. 37fb65dd7763f7cbd1a53f613bbda16d739f11a3