### PR TITLE
White-label home config directory

### DIFF
--- a/cctrl/app_commands.py
+++ b/cctrl/app_commands.py
@@ -472,4 +472,4 @@ def setup_cli(settings):
     except KeyboardInterrupt:
         pass
     finally:
-        common.shutdown(api)
+        common.shutdown(api, settings)

--- a/cctrl/auth.py
+++ b/cctrl/auth.py
@@ -28,10 +28,9 @@ except ImportError:
     import simplejson as json
 
 from cctrl.error import messages, PasswordsDontMatchException
-from cctrl.settings import TOKEN_FILE_PATH, HOME_PATH
 
 
-def update_tokenfile(api):
+def update_tokenfile(api, settings):
     """
         Because it is a real pain we don't want to ask developers for their
         username and password every time they call a method.
@@ -42,19 +41,19 @@ def update_tokenfile(api):
         request resets the expiration time.
     """
     if api.check_token():
-        write_tokenfile(api)
+        write_tokenfile(api, settings)
         return True
     return False
 
 
-def read_tokenfile():
+def read_tokenfile(settings):
     """
-        Read the token from the token_file in TOKEN_FILE_PATH specified in
+        Read the token from the token_path specified in
         cctrl.settings
     """
     token = None
-    if os.path.exists(TOKEN_FILE_PATH):
-        token_file = open(TOKEN_FILE_PATH, "r")
+    if os.path.exists(settings.token_path):
+        token_file = open(settings.token_path, "r")
         try:
             token = json.load(token_file)
         except ValueError:
@@ -63,32 +62,32 @@ def read_tokenfile():
     return token
 
 
-def write_tokenfile(api):
+def write_tokenfile(api, settings):
     """
         This method checks, if the .cloudControl directory inside the
         users home exists or is a file. If not, we create it and then
         write the token file.
     """
-    if os.path.isdir(HOME_PATH):
+    if os.path.isdir(settings.home_path):
         pass
-    elif os.path.isfile(HOME_PATH):
-        print 'Error: ' + HOME_PATH + ' is a file, not a directory.'
+    elif os.path.isfile(settings.home_path):
+        print 'Error: ' + settings.home_path + ' is a file, not a directory.'
         sys.exit(1)
     else:
-        os.mkdir(HOME_PATH)
+        os.mkdir(settings.home_path)
 
-    tokenfile = open(TOKEN_FILE_PATH, "w")
-    json.dump(api.get_token(), tokenfile)
-    tokenfile.close()
+    token_file = open(settings.token_path, "w")
+    json.dump(api.get_token(), token_file)
+    token_file.close()
     return True
 
 
-def delete_tokenfile():
+def delete_tokenfile(settings):
     """
         We delete the tokenfile if we don't have a valid token to save.
     """
-    if os.path.exists(TOKEN_FILE_PATH):
-        os.remove(TOKEN_FILE_PATH)
+    if os.path.exists(settings.token_path):
+        os.remove(settings.token_path)
         return True
     return False
 

--- a/cctrl/common.py
+++ b/cctrl/common.py
@@ -65,7 +65,7 @@ def init_api(settings):
             break
 
         dirname = os.path.dirname(dirname)
-    return cclib.API(token=read_tokenfile(),
+    return cclib.API(token=read_tokenfile(settings),
                      url=settings.api_url,
                      token_source_url=settings.token_source_url,
                      register_addon_url=settings.register_addon_url,
@@ -134,12 +134,12 @@ def run(args, api, settings):
     execute_with_authenticated_user(api, (lambda: args.func(args)), settings)
 
 
-def shutdown(api):
+def shutdown(api, settings):
     """
         shutdown handles updating or deleting the token file on disk each time
         cctrl finishes or gets interrupted.
     """
     if api.check_token():
-        update_tokenfile(api)
+        update_tokenfile(api, settings)
     else:
-        delete_tokenfile()
+        delete_tokenfile(settings)

--- a/cctrl/dcapp
+++ b/cctrl/dcapp
@@ -26,5 +26,6 @@ if __name__ == "__main__":
                         ssh_forwarder_url='sshforwarder.dotcloudapp.com',
                         login_creds={'email': 'DC_EMAIL',
                                      'pwd': 'DC_PASSWORD'},
-                        package_name='dotcloudng')
+                        package_name='dotcloudng',
+                        home_path='.dotcloudapp.com')
     setup_cli(settings)

--- a/cctrl/exoapp
+++ b/cctrl/exoapp
@@ -27,5 +27,6 @@ if __name__ == "__main__":
                         ssh_forwarder_url='sshforwarder.app.exo.io',
                         login_name='Email or Organization ID: ',
                         login_creds={'email': 'EXO_EMAIL',
-                                     'pwd': 'EXO_PASSWORD'})
+                                     'pwd': 'EXO_PASSWORD'},
+                        home_path='.app.exo.io')
     setup_cli(settings)

--- a/cctrl/settings.py
+++ b/cctrl/settings.py
@@ -18,9 +18,6 @@
 import os
 from cctrl.version import __version__
 
-HOME_PATH = os.path.abspath(os.path.expanduser('~/.cloudControl'))
-TOKEN_FILE_NAME = os.environ.get('CCTRL_TOKEN_FILE', 'token.json')
-TOKEN_FILE_PATH = os.path.join(HOME_PATH, TOKEN_FILE_NAME)
 VERSION = __version__
 CONFIG_ADDON = os.getenv('CONFIG_ADDON', 'config.free')
 
@@ -40,7 +37,8 @@ class Settings(object):
                  login_creds={'email': 'CCTRL_EMAIL',
                               'pwd': 'CCTRL_PASSWORD'},
                  package_name='cctrl',
-                 prefix_project_name=False):
+                 prefix_project_name=False,
+                 home_path='.cloudControl'):
 
         self.ssh_forwarder = ssh_forwarder_url or env.get('SSH_FORWARDER', 'sshforwarder.cloudcontrolled.com')
         self.ssh_forwarder_port = '2222'
@@ -55,3 +53,5 @@ class Settings(object):
         self.login_creds = login_creds
         self.package_name = package_name
         self.prefix_project_name = prefix_project_name
+        self.home_path = os.path.abspath(os.path.expanduser('~/{}'.format(home_path)))
+        self.token_path = os.path.join(self.home_path, 'token.json')

--- a/cctrl/user_commands.py
+++ b/cctrl/user_commands.py
@@ -153,4 +153,4 @@ def setup_cli(settings):
     except KeyboardInterrupt:
         pass
     finally:
-        common.shutdown(api)
+        common.shutdown(api, settings)


### PR DESCRIPTION
Previously, the home config directory was hardcoded
to `.cloudControl` regardless of the platform you were working on.

For instance, when creating the user authentication token,
they were all saved in this directory. It gave the possibility to
name the token file to distinguish from the default `token.json`
file.

With this commit, each platform will have a specific home config
directory. The token file is called `token.json` and it will be
stored inside the home config directory of the platform is authenticating
on.

This is a first step to introduce user specific configuration for
each platform.