### PR TITLE
Add setting to enable/disable version checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+* 8318e62 - Logout user when setup email differs
+* a0addbe - Add setting to enable/disable version checks
 * 23aa70a - Deprecate ez_setup.py file
 * c0318e2 - Add VersionEye support
 * ba2d6fa - Upgrade requirements.txt

--- a/cctrl/app_commands.py
+++ b/cctrl/app_commands.py
@@ -44,14 +44,18 @@ class list_action(argparse.Action):
 
     def __call__(self, parser, namespace, value, option_string=None):
         try:
-            common.check_for_updates(self.settings.package_name, self.api.check_versions()['cctrl'])
+            if self.settings.check_for_updates:
+                common.check_for_updates(self.settings.package_name,
+                                         self.api.check_versions()['cctrl'])
         except KeyError:
             pass
         except ConnectionException:
             pass
 
         apps = AppsController(self.api)
-        common.execute_with_authenticated_user(self.api, lambda: apps.list(), self.settings)
+        common.execute_with_authenticated_user(self.api,
+                                               lambda: apps.list(),
+                                               self.settings)
         parser.exit()
 
 

--- a/cctrl/auth.py
+++ b/cctrl/auth.py
@@ -16,12 +16,13 @@
 """
 import os
 import sys
-
 from __builtin__ import open, raw_input, range
 from exceptions import ImportError, ValueError
 
 import ConfigParser
+from ConfigParser import NoOptionError
 from getpass import getpass
+
 from cctrl.oshelpers import recode_input
 
 try:
@@ -140,7 +141,13 @@ def set_user_config(settings, email=None, ssh_auth=None, ssh_path=None):
     if not config.has_section('user'):
         config.add_section('user')
 
-    if email:
+    try:
+        current_email = config.get('user', 'email')
+    except NoOptionError:
+        current_email = None
+
+    if email and email != current_email:
+        delete_tokenfile(settings)
         config.set('user', 'email', email)
 
     if ssh_auth is not None:

--- a/cctrl/settings.py
+++ b/cctrl/settings.py
@@ -39,11 +39,14 @@ class Settings(object):
                  package_name='cctrl',
                  prefix_project_name=False,
                  home_path='.cloudControl',
-                 ssh_auth=True):
+                 ssh_auth=True,
+                 check_for_updates=True):
 
-        self.ssh_forwarder = ssh_forwarder_url or env.get('SSH_FORWARDER', 'sshforwarder.cloudcontrolled.com')
+        self.ssh_forwarder = ssh_forwarder_url or env.get('SSH_FORWARDER',
+                                                          'sshforwarder.cloudcontrolled.com')
         self.ssh_forwarder_port = '2222'
-        self.api_url = api_url or env.get('CCTRL_API_URL', 'https://api.cloudcontrolled.com')
+        self.api_url = api_url or env.get('CCTRL_API_URL',
+                                          'https://api.cloudcontrolled.com')
         self.token_source_url = token_source_url or self.api_url + '/token/'
         self.encode_email = encode_email
         self.user_registration_enabled = user_registration_enabled
@@ -58,3 +61,4 @@ class Settings(object):
         self.token_path = os.path.join(self.home_path, 'token.json')
         self.config_path = os.path.join(self.home_path, 'user.cfg')
         self.ssh_auth = ssh_auth
+        self.check_for_updates = check_for_updates

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -59,3 +59,12 @@ class TestSettings(unittest.TestCase):
         test_env = {'SSH_FORWARDER': "my.ssh_forwarder.url"}
         settings = Settings(env=test_env)
         self.assertEqual('my.ssh_forwarder.url', settings.ssh_forwarder)
+
+    def test_check_for_updates_default(self):
+        settings = Settings(env={})
+        self.assertTrue(settings.check_for_updates)
+
+    def test_check_for_updates_set_by_argument(self):
+        settings = Settings(api_url='any.api.url',
+                            check_for_updates=False)
+        self.assertFalse(settings.check_for_updates)


### PR DESCRIPTION
Since we use this package as base for another CLI implementations,
package version won't always match, so users of these CLI tools
might always get annoying warnings on new available version.

Also, logout user when setup email differs.

Also, pep8 fixes.